### PR TITLE
(AZUREVIYA-115) Unlimited license support

### DIFF
--- a/sas-viya/playbooks/roles/read_sas_license_information/lookup_plugins/sas_license.py
+++ b/sas-viya/playbooks/roles/read_sas_license_information/lookup_plugins/sas_license.py
@@ -55,6 +55,8 @@ class SasLicenseCPU:
                         'serial': self.serial}
         if self.serial.startswith('+'):
             ansible_dict['licensed_cores'] = int(self.serial.lstrip('+'))
+        else:
+            ansible_dict['licensed_cores'] = -1
 
         return ansible_dict
 


### PR DESCRIPTION
- most minimal change enables licences to default to a 4 core sku on an unlimited license.