### PR TITLE
(AZUREVIYA-175) Add contribution files per SAS open source guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a signed
+[Contributor Agreement](ContributorAgreement.txt).
+You (or your employer) retain the copyright to your contribution,
+this simply gives us permission to use and redistribute your contributions as
+part of the project.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 # How to Contribute
 
-We'd love to accept your patches and contributions to this project. There are
-just a few small guidelines you need to follow.
+We welcome your patches and contributions to this project. However, there are
+a few guidelines that you need to follow.
 
 ## Contributor License Agreement
 
 Contributions to this project must be accompanied by a signed
 [Contributor Agreement](ContributorAgreement.txt).
-You (or your employer) retain the copyright to your contribution,
-this simply gives us permission to use and redistribute your contributions as
+You (or your employer) retain the copyright to your contributions.
+This gives us permission to use and redistribute your contributions as
 part of the project.
 
-## Code reviews
+## Code Reviews
 
 All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult

--- a/ContributorAgreement.txt
+++ b/ContributorAgreement.txt
@@ -1,0 +1,56 @@
+Contributor Agreement
+
+Version 1.1
+
+Contributions to this software are accepted only when they are
+properly accompanied by a Contributor Agreement. The Contributor
+Agreement for this software is the Developer's Certificate of Origin
+1.1 (DCO) as provided with and required for accepting contributions
+to the Linux kernel.
+
+In each contribution proposed to be included in this software, the
+developer must include a "sign-off" that denotes consent to the
+terms of the Developer's Certificate of Origin.  The sign-off is
+a line of text in the description that accompanies the change,
+certifying that you have the right to provide the contribution
+to be included.  For changes provided in source code control (for
+example, via a Git pull request) the sign-off must be included in
+the commit message in source code control.  For changes provided
+in email or issue tracking, the sign-off must be included in the
+email or the issue, and the sign-off will be incorporated into the
+permanent commit message if the contribution is accepted into the
+official source code.
+
+If you can certify the below:
+
+        Developer's Certificate of Origin 1.1
+
+        By making a contribution to this project, I certify that:
+
+        (a) The contribution was created in whole or in part by me and I
+            have the right to submit it under the open source license
+            indicated in the file; or
+
+        (b) The contribution is based upon previous work that, to the best
+            of my knowledge, is covered under an appropriate open source
+            license and I have the right under that license to submit that
+            work with modifications, whether created in whole or in part
+            by me, under the same open source license (unless I am
+            permitted to submit under a different license), as indicated
+            in the file; or
+
+        (c) The contribution was provided directly to me by some other
+            person who certified (a), (b) or (c) and I have not modified
+            it.
+
+        (d) I understand and agree that this project and the contribution
+            are public and that a record of the contribution (including all
+            personal information I submit with it, including my sign-off) is
+            maintained indefinitely and may be redistributed consistent with
+            this project or the open source license(s) involved.
+
+then you just add a line saying
+
+        Signed-off-by: Random J Developer <random@developer.example.org>
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)


### PR DESCRIPTION
This commit adds the standard SAS CONTIRBUTOR.md and ContributionAgreement.txt files
per SAS open source guidelines.